### PR TITLE
Throw if composed stream emits array

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@cycle/run": "^3.0.0",
-    "snabbdom-selector": "^1.2.0",
+    "snabbdom-selector": "^1.3.2",
     "xstream": "^11.0.0"
   },
   "devDependencies": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,6 +50,8 @@ export function addKeys(
     node: VNode,
     key: string = Math.random().toString()
 ): VNode {
+    if (!node) return;
+
     if (!node.children) {
         return { ...node, key: node.key ? node.key : key };
     }

--- a/src/makeSortable.ts
+++ b/src/makeSortable.ts
@@ -37,7 +37,11 @@ function augmentStartDistance(
 }
 
 function moreThanOneChild(node: VNode) {
-    return !node.children || node.children.length > 1;
+    if (Array.isArray(node)) {
+        throw new Error('Composed stream should emit VNodes not arrays');
+    }
+
+    return !node || node.children.length > 1;
 }
 
 function notMoreThanOneChild(node: VNode) {


### PR DESCRIPTION
Ensures the user does not emit arrays directly, but wraps VNode arrays in a parent VNode before composing with `makeSortable`